### PR TITLE
Implementation of #each with index

### DIFF
--- a/st.js
+++ b/st.js
@@ -321,7 +321,31 @@
                 if (newData && Helper.is_array(newData)) {
                   result = [];
                   for (var index = 0; index < newData.length; index++) {
+                    // temporarily set $index
+                    if(typeof newData[index] === 'object') {
+                      newData[index]["$index"] = index;
+                    } else {
+                      String.prototype.$index = index;
+                      Number.prototype.$index = index;
+                      Function.prototype.$index = index;
+                      Array.prototype.$index = index;
+                      Boolean.prototype.$index = index;
+                    }
+
+                    // run
                     var loop_item = TRANSFORM.run(template[key], newData[index]);
+
+                    // clean up $index
+                    if(typeof newData[index] === 'object') {
+                      delete newData[index]["$index"];
+                    } else {
+                      delete String.prototype.$index;
+                      delete Number.prototype.$index;
+                      delete Function.prototype.$index;
+                      delete Array.prototype.$index;
+                      delete Boolean.prototype.$index;
+                    }
+
                     if (loop_item) {
                       // only push when the result is not null
                       // null could mean #if clauses where nothing matched => In this case instead of rendering 'null', should just skip it completely
@@ -796,7 +820,7 @@
     if (!replacer) {
       return _stringify(val, function(key, val) {
         if (SELECT.$injected && SELECT.$injected.length > 0 && SELECT.$injected.indexOf(key) !== -1) { return undefined; }
-        if (key === '$root') {
+        if (key === '$root' || key === '$index') {
           return undefined;
         }
         if (typeof val === 'function') {

--- a/st.js
+++ b/st.js
@@ -312,6 +312,19 @@
                       result[key] = res[key];
                     }
                   });
+                  // clean up $index from the result
+                  // necessary because #merge merges multiple objects into one,
+                  // and one of them may be 'this', in which case the $index attribute
+                  // will have snuck into the final result
+                  if(typeof data === 'object') {
+                    delete result["$index"];
+                  } else {
+                    delete String.prototype.$index;
+                    delete Number.prototype.$index;
+                    delete Function.prototype.$index;
+                    delete Array.prototype.$index;
+                    delete Boolean.prototype.$index;
+                  }
                 }
               } else if (fun.name === '#each') {
                 // newData will be filled with parsed results

--- a/test/unit/transform/loop.js
+++ b/test/unit/transform/loop.js
@@ -116,6 +116,44 @@ describe('#each', function(){
       ];
       compare(actual, expected);
     })
+    it('use with #merge', function() {
+      var template = {
+        "users": {
+          "{{#each $root.$get.users}}": {
+            "{{#merge}}": [
+              "{{this}}",
+              { "balance": "{{$root.$jason[$index]}}" , "index": "{{$index}}" }
+            ]
+          }
+        }
+      };
+      var data = {
+        "$get": {
+          "users": [{
+            "id": "0xdef",
+            "username": "Alice"
+          }, {
+            "id": "0xabc",
+            "username": "Bob"
+          }]
+        },
+        "$jason": [100, 58]
+      }
+      var actual = st.TRANSFORM.transform(template, data);
+      compare(actual, {
+        "users": [{
+          "id": "0xdef",
+          "username": "Alice",
+          "balance": 100,
+          "index": 0
+        }, {
+          "id": "0xabc",
+          "username": "Bob",
+          "balance": 58,
+          "index": 1
+        }]
+      })
+    });
   });
   /*
   it('#each with $index', function() {

--- a/test/unit/transform/loop.js
+++ b/test/unit/transform/loop.js
@@ -39,6 +39,84 @@ describe('#each', function(){
     var actual = st.TRANSFORM.run(template, data);
     compare(actual, template);
   });
+  describe('#each with index', function() {
+    it("primitive", function() {
+      var data = {"items": ["a", "b", "c"]}
+      var template = {
+        "{{#each items}}": {
+          "primitive": "{{this}}",
+          "index": "{{$index}}"
+        }
+      };
+      var actual = st.TRANSFORM.run(template, data);
+      compare(actual, [{"primitive": "a", "index": 0}, {"primitive": "b", "index": 1}, {"primitive": "c", "index": 2}]);
+    })
+    it("array", function() {
+      var data = {"items": [["a"], ["b"], ["c"]]}
+      var template = {
+        "{{#each items}}": {
+          "array": "{{this}}",
+          "index": "{{$index}}"
+        }
+      };
+      var actual = st.TRANSFORM.run(template, data);
+      compare(actual, [{"array": ["a"], "index": 0}, {"array": ["b"], "index": 1}, {"array": ["c"], "index": 2}]);
+    })
+    it("object", function() {
+      var data = {"items": [{name: "kate", age: "23"}, {name: "Lassie", age: "3"}]};
+      var template = {
+        "{{#each items}}": {
+          "title": "{{name}}",
+          "subtitle": "{{age}}",
+          "index": "{{$index}}"
+        }
+      };
+      var actual = st.TRANSFORM.run(template, data);
+      compare(actual, [{"title": "kate", "subtitle": "23", "index": 0}, {"title": "Lassie", "subtitle": "3", "index": 1}]);
+    })
+    it("nested array", function() {
+      var data = {"items": [["a1", "a2", "a3"], ["b1", "b2", "b3"], ["c1", "c2", "c3"]]}
+      var template = {
+        "{{#each items}}": {
+          "index": "{{$index}}",
+          "items": {
+            "{{#each this}}": {
+              "item": "{{this}}",
+              "index": "{{$index}}"
+            }
+          }
+        }
+      };
+      var actual = st.TRANSFORM.run(template, data);
+      var expected = [
+        {
+          "index": 0,
+          "items": [
+            { "item": "a1", "index": 0 },
+            { "item": "a2", "index": 1 },
+            { "item": "a3", "index": 2 }
+          ]
+        },
+        {
+          "index": 1,
+          "items": [
+            { "item": "b1", "index": 0 },
+            { "item": "b2", "index": 1 },
+            { "item": "b3", "index": 2 }
+          ]
+        },
+        {
+          "index": 2,
+          "items": [
+            { "item": "c1", "index": 0 },
+            { "item": "c2", "index": 1 },
+            { "item": "c3", "index": 2 }
+          ]
+        }
+      ];
+      compare(actual, expected);
+    })
+  });
   /*
   it('#each with $index', function() {
     var data = {"items": ['a','b','c','d']};


### PR DESCRIPTION
Currently we do not have a way to access the current index within an `#each` loop.

This adds a special attribute called `$index` which can be accessed within #each loops.

You can use the `$index` attribute within loops like this:

```
{
  "{{#each items}}": {
    "index": "{{$index}}",
    "items": {
      "{{#each this}}": {
        "item": "{{this}}",
        "index": "{{$index}}"
      }
    }
  }
}
```

As you can see, it fully supports nested #each loops as well.