### PR TITLE
Define local vars that survive even inside #each loops

### DIFF
--- a/st.js
+++ b/st.js
@@ -172,6 +172,7 @@
     },
   };
   var TRANSFORM = {
+    memory: {},
     transform: function(template, data, injection, serialized) {
       var selector = null;
       if (/#include/.test(JSON.stringify(template))) {
@@ -295,6 +296,23 @@
             if (fun) {
               if (fun.name === '#include') {
                 // this was handled above (before the for loop) so just ignore
+              } else if (fun.name === '#let') {
+                if (Helper.is_array(template[key]) && template[key].length == 2) {
+                  var defs = template[key][0];
+                  var real_template = template[key][1];
+
+                  // 1. Parse the first item to assign variables
+                  var parsed_keys = TRANSFORM.run(defs, data);
+
+                  // 2. modify the data
+                  for(var parsed_key in parsed_keys) {
+                    TRANSFORM.memory[parsed_key] = parsed_keys[parsed_key];
+                    data[parsed_key] = parsed_keys[parsed_key];
+                  }
+
+                  // 2. Pass it into TRANSFORM.run
+                  result = TRANSFORM.run(real_template, data);
+                }
               } else if (fun.name === '#concat') {
                 if (Helper.is_array(template[key])) {
                   result = [];
@@ -326,12 +344,26 @@
                   // will have snuck into the final result
                   if(typeof data === 'object') {
                     delete result["$index"];
+
+                    // #let handling
+                    for (var declared_vars in TRANSFORM.memory) {
+                      delete result[declared_vars];
+                    }
                   } else {
                     delete String.prototype.$index;
                     delete Number.prototype.$index;
                     delete Function.prototype.$index;
                     delete Array.prototype.$index;
                     delete Boolean.prototype.$index;
+
+                    // #let handling
+                    for (var declared_vars in TRANSFORM.memory) {
+                      delete String.prototype[declared_vars];
+                      delete Number.prototype[declared_vars];
+                      delete Function.prototype[declared_vars];
+                      delete Array.prototype[declared_vars];
+                      delete Boolean.prototype[declared_vars];
+                    }
                   }
                 }
               } else if (fun.name === '#each') {
@@ -345,12 +377,24 @@
                     // temporarily set $index
                     if(typeof newData[index] === 'object') {
                       newData[index]["$index"] = index;
+                      // #let handling
+                      for (var declared_vars in TRANSFORM.memory) {
+                        newData[index][declared_vars] = TRANSFORM.memory[declared_vars];
+                      }
                     } else {
                       String.prototype.$index = index;
                       Number.prototype.$index = index;
                       Function.prototype.$index = index;
                       Array.prototype.$index = index;
                       Boolean.prototype.$index = index;
+                      // #let handling
+                      for (var declared_vars in TRANSFORM.memory) {
+                        String.prototype[declared_vars] = TRANSFORM.memory[declared_vars];
+                        Number.prototype[declared_vars] = TRANSFORM.memory[declared_vars];
+                        Function.prototype[declared_vars] = TRANSFORM.memory[declared_vars];
+                        Array.prototype[declared_vars] = TRANSFORM.memory[declared_vars];
+                        Boolean.prototype[declared_vars] = TRANSFORM.memory[declared_vars];
+                      }
                     }
 
                     // run
@@ -359,12 +403,24 @@
                     // clean up $index
                     if(typeof newData[index] === 'object') {
                       delete newData[index]["$index"];
+                      // #let handling
+                      for (var declared_vars in TRANSFORM.memory) {
+                        delete newData[index][declared_vars];
+                      }
                     } else {
                       delete String.prototype.$index;
                       delete Number.prototype.$index;
                       delete Function.prototype.$index;
                       delete Array.prototype.$index;
                       delete Boolean.prototype.$index;
+                      // #let handling
+                      for (var declared_vars in TRANSFORM.memory) {
+                        delete String.prototype[declared_vars];
+                        delete Number.prototype[declared_vars];
+                        delete Function.prototype[declared_vars];
+                        delete Array.prototype[declared_vars];
+                        delete Boolean.prototype[declared_vars];
+                      }
                     }
 
                     if (loop_item) {
@@ -847,6 +903,9 @@
       return _stringify(val, function(key, val) {
         if (SELECT.$injected && SELECT.$injected.length > 0 && SELECT.$injected.indexOf(key) !== -1) { return undefined; }
         if (key === '$root' || key === '$index') {
+          return undefined;
+        }
+        if (key in TRANSFORM.memory) {
           return undefined;
         }
         if (typeof val === 'function') {

--- a/test/unit/transform/let.js
+++ b/test/unit/transform/let.js
@@ -1,0 +1,157 @@
+var assert = require('assert');
+var st = require('../../../st.js');
+var _ = require("underscore");
+var stringify = require('json-stable-stringify');
+
+var compare = function(actual, expected){
+  assert.equal(stringify(actual), stringify(expected));
+};
+
+/*****
+
+  #let API:
+
+  takes an array of 2 items as argument.
+
+  item 0: The variables to assign
+  item 1: The template to transform
+
+  Warning: make sure to use unique variable names, otherwise you may override unexpected variables and it may fail.
+
+*****/
+
+describe('$parent', function(){
+  it("without #let assignment the context is different therefore transform doesn't work", function() {
+    let data = {
+      "verbs": ["buy", "use", "break", "fix"],
+      "object": "it"
+    }
+    let template = {
+      "{{#each verbs}}": "{{this}} {{object}}"
+    }
+    let actual = st.TRANSFORM.transform(template,data);
+    let expected = [
+      'buy {{object}}',
+      'use {{object}}',
+      'break {{object}}',
+      'fix {{object}}'
+    ];
+    compare(actual, expected);
+  })
+  it("WITH #let assignment, variables exist all throughout the transform", function() {
+    let data = {
+      "verbs": ["buy", "use", "break", "fix"],
+      "object": "it"
+    }
+    let template = {
+      "{{#let}}": [{
+          "object": "{{object}}"
+        },
+        {
+          "{{#each verbs}}": "{{this}} {{object}}"
+        }
+      ]
+    }
+    let actual = st.TRANSFORM.transform(template,data);
+    let expected = [
+      'buy it',
+      'use it',
+      'break it',
+      'fix it'
+    ];
+    compare(actual, expected);
+  })
+  it("works through multiple loops all the way to the leaf node", function() {
+    let data = {
+      "verses": [
+        ["buy", "use", "break", "fix"],
+        ["charge", "point", "zoom", "press"]
+      ],
+      "object": "it"
+    }
+    let template = {
+      "{{#let}}": [{
+          "object": "{{object}}"
+        },
+        {
+          "{{#each verses}}": {
+            "{{#each this}}": "{{this}} {{object}}"
+          }
+        }
+      ]
+    }
+    let actual = st.TRANSFORM.transform(template,data);
+    let expected = [
+      [ 'buy it', 'use it', 'break it', 'fix it' ],
+      [ 'charge it', 'point it', 'zoom it', 'press it' ]
+    ];
+    compare(actual, expected);
+  })
+  it("using external library", function() {
+    let data = {
+      "items": [{
+        "children": ["A", "A", "B", "C", "C", "D", "E", "E"]
+      }, {
+        "children": ["A", "A", "A", "A"]
+      }]
+    }
+    let template = {
+      "{{#let}}": [
+        {
+          "_": _
+        },
+        {
+          "{{#each items}}": {
+            "{{#each _.uniq(children)}}": {
+              "text": "{{this}}"
+            }
+          }
+        }
+      ]
+    }
+    let actual = st.TRANSFORM.transform(template,data);
+    let expected = [
+      [ 
+        { text: 'A' },
+        { text: 'B' },
+        { text: 'C' },
+        { text: 'D' },
+        { text: 'E' }
+      ],
+      [ 
+        { text: 'A' }
+      ]
+    ]
+    compare(actual, expected);
+  })
+  it("#each", function() {
+    let data = {
+      items: [{
+        name: "Alice",
+        items: ["A", "L", "I"]
+      }, {
+        name: "Bob",
+        items: ["B", "O", "B"]
+      }]
+    }
+    let template = {
+      "{{#each items}}": {
+        "{{#let}}": [
+          {
+            "$parent": "{{this}}",
+            "$parent_index": "{{$index}}"
+          },
+          {
+            "{{#each items}}": "{{$parent.name}} {{$parent_index.toString()}} {{this}}"
+          }
+        ]
+      }
+    }
+    var actual = st.TRANSFORM.transform(template,data);
+    var expected = [
+      ["Alice 0 A", "Alice 0 L", "Alice 0 I"],
+      ["Bob 1 B", "Bob 1 O", "Bob 1 B"]
+    ]
+    compare(actual, expected);
+  })
+})


### PR DESCRIPTION
There was no way to define local variables that could exist all throughout the parsing process.

The `#let` method lets you do that. See the test file in the commit for details